### PR TITLE
docs: fix token mint comment

### DIFF
--- a/Sources/SolanaSwift/BlockchainClient/BlockchainClient+Extensions.swift
+++ b/Sources/SolanaSwift/BlockchainClient/BlockchainClient+Extensions.swift
@@ -50,7 +50,7 @@ public extension SolanaBlockchainClient {
     /// Prepare instructions for creating associated token account and close if needed
     /// - Parameters:
     ///   - owner: The owner of new WSOL account
-    ///   - mint: The mint of ther token
+    ///   - mint: The mint of the token
     ///   - feePayer: The payer of the transaction (usually the owner)
     ///   - closeAfterward: close after done or not
     /// - Returns: AccountInstructions that contains needed instructions, signers, .etc


### PR DESCRIPTION
## Summary
- fix grammar in doc comment for `prepareForCreatingAssociatedTokenAccount`

## Testing
- `swift test -l` *(fails: no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_6849efbe8e988324b76ccbd3913c19db