### PR TITLE
Fix socket log message

### DIFF
--- a/Sources/SolanaSwift/Socket/Socket.swift
+++ b/Sources/SolanaSwift/Socket/Socket.swift
@@ -262,7 +262,7 @@ extension Socket: URLSessionWebSocketDelegate {
         }
         delegate?.connected()
 
-        Logger.log(event: "urlSession", message: "Socket disconnected", logLevel: .debug)
+        Logger.log(event: "urlSession", message: "Socket connected", logLevel: .debug)
 
         asyncTask = Task.detached { [weak self] in
             while true {


### PR DESCRIPTION
## Summary
- correct the log message when the WebSocket connection opens

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_6849efce8d348324b76100f1853195b8