### PR TITLE
docs: fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Solana-blockchain client, written in pure swift.
 [See more](https://github.com/p2p-org/solana-swift/blob/main/CHANGELOG.md)
 
 ### v2.0
-- From v2.0.0 we officially omited Rx library and a lot of dependencies, thus we also adopt swift concurrency to `solana-swift`. [What have been changed?](https://github.com/p2p-org/solana-swift/issues/42)
+- From v2.0.0 we officially omitted Rx library and a lot of dependencies, thus we also adopt swift concurrency to `solana-swift`. [What have been changed?](https://github.com/p2p-org/solana-swift/issues/42)
 - For those who still use `SolanaSDK` class, follow [this link](https://github.com/p2p-org/solana-swift/blob/deprecated/1.3.8/README.md)
 
 ## Features


### PR DESCRIPTION
## Summary
- fix `omitted` spelling typo in README

## Testing
- `swift test -l` *(fails: no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_6849efb0a16c832484d5c174ff052ddd